### PR TITLE
Viðbætur við „validate“ og „validation“

### DIFF
--- a/data/dict/_add.txt
+++ b/data/dict/_add.txt
@@ -2391,7 +2391,7 @@ reread s. endurlesa
 prosciutto n. þunnskorin ítölsk skinka
 neuron n. taugungur, taugafruma
 phrenologist n. höfuðlagsfræðingur
-phrenological l. höfuðlagsfræðilegur
+phrenological l. höfuðlagsfræðilegur, höfuðlags-
 waistline n. mittismál; mitti
 telemarketer n. símasölumaður
 telemarketing n. símasölumennska
@@ -11994,7 +11994,7 @@ scuba diving n. köfun (með köfunartæki)
 gruelling l. erfiður, þreytandi, lýjandi
 customhouse n. tollbúð, tollstöð
 customs nft. tollur; tollgæsla ([he had to go through ~]); siðir, siðvenjur
-customs duty n. tollgjald, innflutningsgjalda, aðflutningsgjald
+customs duty n. tollgjald, innflutningsgjald, aðflutningsgjald
 relevance n. vægi, gildi, þýðing
 shipboard n. skipsfjöl; l. um borð í skipi
 slanted l. skáhallur; bjagaður, hlutdrægur ([~ in his judgment])
@@ -12017,7 +12017,16 @@ calibrated l. kvarðaður; fínstilltur
 calibrator n. kvarðari
 basileus n. konungur, keisari (í austrómverska ríkinu)
 welsh s. forðast greiðslu; svíkja loforð
-undoable l. ógeranlegur, ógjörlegur
 demo n. sýningareintak; demó (sýningarupptaka tónlistarmanns); l. kynningar-, sýningar-
 yenta n. kjaftaskur, slúðrari, kjaftakerling (jiddískt slangur)
-scrapyard n. skranport
+scrapyard n. skranport; partaverkstæði (fyrir vélar, bíla, o.s.frv.)
+waterfront n. sjávarbakki; árbakki; hafnarbakki, hafnarsvæði (í borg)
+syncopation n. úrfelling stafs úr miðju orði, samdráttur; misgengi eða breytilegar áherslur (í takti)
+syncopated l. samandreginn, styttur (um orð); misgengur, með mislöngum áherslum (um takt)
+window ledge n. gluggakista
+economic historian n. hagsögufræðingur, hagsagnfræðingur
+night sweat n. nætursviti
+lookism n. útlitsfordómar
+multidimensionality n. margvíðni (sjá %[multidimensional]%)
+metalist n. sjá %[metallist]%
+# undoable l. ógeranlegur, ógjörlegur

--- a/data/dict/d.txt
+++ b/data/dict/d.txt
@@ -1366,7 +1366,7 @@ dizen s. hlaða skrauti utan á ([~ed with gold and jewels])
 dizziness n. svimi, sundl
 dizzy l. svimagjarn; svimandi, sundlandi; s. láta sundla; rugla
 do s. gera; framkvæma; ljúka við; starfa; hegða sér, breyta; duga, nægja; [~ him harm] gera honum mein; [it does him credit] það er honum til sóma; [~ a room] taka til í herbergi; [he did Lear] hann lék Lear; [~ a distance] fara svo eða svo langa vegalengd; [~ or die] duga eða drepast; [to have done writing] hafa lokið við að skrifa; [have done!] hættu! [thy will be done] verði þinn vilji; [~ a sum] reikna dæmi; [~ well] ganga vel, heppnast ([your affairs are ~ing well]); [how ~ you ~]? hvernig liður þér? sæll vertu, o.s.frv.; [~ away (with)] with gera enda á e-u, útrýma; [~ (to others) as you would be done by] breyttu við aðra, eins og þú vilt að aðrir breyti við þig; [~ for] gera út af við; [~ into English] þýða á ensku; [~ to death] drepa; [~ up] gera við; búa um (böggul); gera út af við; leika á e-n; hafa af e-m; [~ with] notast við; komast af með e-ð; [~ without] komast af án e-s, geta verið án e-s; n. bragð, svik
-doable l. geranlegur, gjörlegur
+doable l. geranlegur, gjörlegur, gerlegur
 docile l. auðsveipur, viðráðanlegur, þægur; námfús
 docility n. auðsveipni, þægð ([to obey with ~]); námfýsi
 dockyard n. skipasmíðastöð, slippur

--- a/data/dict/g.txt
+++ b/data/dict/g.txt
@@ -517,7 +517,7 @@ goosy l. gæsarlegur; heimskur, flónskulegur, aulalegur
 gorcock n. skoskur rjúpkarri
 gorcrow n. svört kráka
 gore n. storknað blóð, blóðlifur; geiri (í fati); þríhyrnd landspilda, landgeiri; s. reka í gegn; reka undir, stanga; [~ each other] stangast
-gorge n. kok, kverkar; (fjall)skarð, gil; s. gleypa, háma í sig ([~ oneself]); troða í, fylla
+gorge n. gljúfur, gil, (fjall)skarð; kok, kverkar; s. gleypa, háma í sig ([~ oneself]); troða í, fylla, troðfylla
 gorgeous l. skrautlegur, litfagur; gullfallegur
 gorgeousness n. skraut, litfegurð; gríðarleg fegurð
 gorget n. hálsbjörg; hálsband, hálsmen

--- a/data/dict/s.txt
+++ b/data/dict/s.txt
@@ -3124,7 +3124,7 @@ synchronism n. samtíðleiki
 synchronistic l. niðurraðaður eftir samtíðleik viðburða
 synchronize s. gerast (vera) samtíðis (e-u [with]); samstilla, samhæfa
 synchronous l. samtímis; samstilltur; samhæfður
-syncopate s. draga saman (orð)
+syncopate s. draga saman, stytta (orð)
 syncope n. úrfelling stafs úr miðju orði, samdráttur; yfirlið
 syndic n. umboðsmaður, fulltrúi
 syndicate n. fjárgróðafélag, samlag, samtök

--- a/data/dict/v.txt
+++ b/data/dict/v.txt
@@ -41,8 +41,8 @@ valiancy n. hreysti, hugprýði
 valiant l. hraustur, hugaður
 valiantly ao. hreystilega
 valid l. gildur
-validate s. staðfesta
-validation n. löggilding
+validate s. staðfesta; [~ someone's feelings or experience] viðurkenna tilfinningar eða upplifun e-s
+validation n. löggilding; viðurkenning
 validity n. gildi
 valise n. (leður)taska, ferðataska
 valley n. dalur

--- a/data/ipa/uk/en2ipa.json
+++ b/data/ipa/uk/en2ipa.json
@@ -69682,5 +69682,8 @@
     "Nazi": "/ˈnɑːt.si/",
     "Nazism": "/ˈnɑːt.sɪ.zəm/",
     "purposefulness": "/ˈpɜː.pəs.fəl.nəs/",
-    "sarin": "/ˈsɑː.rɪn/"
+    "sarin": "/ˈsɑː.rɪn/",
+    "lookism": "/ˈlʊk.ɪ.zəm/",
+    "multidimensionality": "/ˌmʌl.ti.daɪ.men.ʃənˈæl.ə.ti/",
+    "ombudsperson": "/ˈɒm.bʊdzˌpɜː.sən/"
 }

--- a/data/ipa_ignore.txt
+++ b/data/ipa_ignore.txt
@@ -2313,3 +2313,8 @@ publically
 thermionic
 unseductive
 war-ridden
+basileus
+calibrator
+ombudsmanship
+praisable
+yenta

--- a/data/missing.txt
+++ b/data/missing.txt
@@ -2433,6 +2433,7 @@ sinusoid
 sinusoidal
 armature (endurskilgreina)
 twerk
+twerking
 terrifically
 plinth
 pointillist
@@ -2781,6 +2782,7 @@ curation
 curate (endurskoða)
 flaming
 brummel
+sass
 sassy
 poppycock
 cephalon
@@ -3345,8 +3347,6 @@ shakily
 snicker
 snickering
 rectus
-syncopation
-syncopated
 refreshing
 refreshingly
 deprived
@@ -6630,11 +6630,9 @@ sherpa
 bundle (endurskoða)
 foosball
 kegel
-calibrator
 miscue
 chocolatier
 dongle
-pigeonhole (endurskoða)
 autotelic
 sighting
 touché
@@ -6647,3 +6645,30 @@ palapa
 posthaste (endurskoða)
 keyman
 overage
+collider
+choreographer
+piledrive
+piledriver
+hooded
+bucket list
+hookum
+fugazi
+shtetl
+rejigger
+rejiggered
+outpaced
+zillennial
+millennial (endurskoða)
+pontooned
+detected
+landscaper
+ischaemic
+steatosis
+asteatosis
+rejuvenating
+heptathlon
+stratocaster
+humbled
+fire hose
+unoriginal
+riveting


### PR DESCRIPTION
Bætir við viðurkenna og viðurkenning fyrir þá merkingu að viðurkenna tilfinningar eða upplifun einhvers, með dæmi sem aðgreinir merkinguna frá eldri þýðingunum (mér fannst dæmi óþarfi í hinu tilfellinu).